### PR TITLE
feat: enable all CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,18 @@ You can also use the Angular CLI `ng` to run your tests
 ng e2e
 ```
 
-Some command-line interface options are available; such as UI mode
+You can use almost the same command-line interface options that exist for Playwright (see [Playwright Docs](https://playwright.dev/docs/test-cli) or use `ng e2e --help`), such as UI mode
 ```bash
 ng e2e --ui
+# or
+npm run e2e -- --ui
 ```
 
-For a list of accepted arguments, use `ng e2e --help`. If you need more options and control on the CLI, the best solution is to use `npx playwright test` directly.
+To specify particular test files, usually done like this `npx playwright test tests/todo-page/ tests/landing-page/`, you have to prepend the `--files` argument.
+```bash
+ng e2e --files tests/todo-page/ --files tests/landing-page/
+```
+The `-c` option is used to choose an Angular configuration. If you also want to specify a Playwright configuration, use `--config` instead.
 
 ### Start an Angular development server
 

--- a/src/builders/playwright/index.spec.ts
+++ b/src/builders/playwright/index.spec.ts
@@ -30,6 +30,10 @@ describe('Playwright builder', () => {
     });
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should spawn testing process', async () => {
     const run = await architect.scheduleBuilder(
       'playwright-ng-schematics:playwright',
@@ -94,6 +98,50 @@ describe('Playwright builder', () => {
     expect(spawn).toHaveBeenCalledWith(
       'npx playwright test',
       ['--ui'],
+      expect.anything(),
+    );
+    expect(output.success).toBeTruthy();
+  });
+
+  it('should accept unknown options', async () => {
+    const run = await architect.scheduleBuilder(
+      'playwright-ng-schematics:playwright',
+      {
+        test1: 'testValue',
+        test2: 2,
+        test3: true,
+        test4: [],
+        test5: {},
+        test6: null,
+        a: 'yes',
+        b: true,
+      },
+    );
+    await run.stop();
+    const output = await run.result;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'npx playwright test',
+      ['--test1', 'testValue', '--test2', '2', '--test3', '-a', 'yes', '-b'],
+      expect.anything(),
+    );
+    expect(output.success).toBeTruthy();
+  });
+
+  it('should accept --files option', async () => {
+    const run = await architect.scheduleBuilder(
+      'playwright-ng-schematics:playwright',
+      {
+        'fail-on-flaky-tests': true,
+        files: ['tests/todo-page/', 'tests/landing-page/'],
+      },
+    );
+    await run.stop();
+    const output = await run.result;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'npx playwright test',
+      ['tests/todo-page/', 'tests/landing-page/', '--fail-on-flaky-tests'],
       expect.anything(),
     );
     expect(output.success).toBeTruthy();

--- a/src/builders/playwright/index.ts
+++ b/src/builders/playwright/index.ts
@@ -8,29 +8,47 @@ import {
 } from '@angular-devkit/architect';
 import type { JsonObject } from '@angular-devkit/core';
 
-interface Options extends JsonObject {
-  devServerTarget: string;
-  debug: boolean;
-  trace: string;
-  'update-snapshots': boolean;
-  ui: boolean;
-}
+/**
+ * Converts the options object back to an argv string array.
+ *
+ * @example
+ * buildArgs({"workers": 2}); // returns ["--workers", 2]
+ */
+function buildArgs(options: JsonObject): string[] {
+  // extract files
+  const filesArgs = (options.files as string[]) ?? [];
+  options.files = null;
 
-function buildArgs(options: Options) {
-  const args = [];
-  if (options.debug) {
-    args.push('--debug');
-  }
-  if (options.trace) {
-    args.push('--trace', options.trace);
-  }
-  if (options['update-snapshots']) {
-    args.push('--u');
-  }
-  if (options.ui) {
-    args.push('--ui');
-  }
-  return args;
+  return [
+    ...filesArgs,
+    ...Object.entries(options).flatMap(([key, value]) => {
+      // Skip builder-internal options
+      if (key === 'devServerTarget') {
+        return [];
+      }
+
+      // Skip objects, arrays, null, undefined (should already be validated by Angular though)
+      if (
+        typeof value === 'object' ||
+        Array.isArray(value) ||
+        value === null ||
+        value === undefined
+      ) {
+        return [];
+      }
+
+      const dashes = key.length === 1 ? '-' : '--';
+      const argument = `${dashes}${key}`;
+
+      if (typeof value === 'boolean') {
+        if (value) {
+          return argument;
+        }
+        return [];
+      }
+      return [argument, String(value)];
+    }),
+  ];
 }
 
 async function startDevServer(
@@ -43,7 +61,7 @@ async function startDevServer(
   return server;
 }
 
-async function startPlaywrightTest(options: Options, baseURL: string) {
+async function startPlaywrightTest(options: JsonObject, baseURL: string) {
   // PLAYWRIGHT_TEST_BASE_URL is actually a non-documented env variable used
   // by Playwright Test.
   // Its usage in playwright.config.ts is to clarify that it can be overriden.
@@ -56,14 +74,14 @@ async function startPlaywrightTest(options: Options, baseURL: string) {
   }
 
   return new Promise((resolve, reject) => {
-    const childPorcess = spawn('npx playwright test', buildArgs(options), {
+    const childProcess = spawn('npx playwright test', buildArgs(options), {
       cwd: process.cwd(),
       stdio: 'inherit',
       shell: true,
       env,
     });
 
-    childPorcess.on('exit', (exitCode) => {
+    childProcess.on('exit', (exitCode) => {
       if (exitCode !== 0) {
         reject(exitCode);
       }
@@ -73,14 +91,17 @@ async function startPlaywrightTest(options: Options, baseURL: string) {
 }
 
 async function runE2E(
-  options: Options,
+  options: JsonObject,
   context: BuilderContext,
 ): Promise<BuilderOutput> {
   let server: BuilderRun | undefined = undefined;
   let baseURL = '';
 
   try {
-    if (options.devServerTarget) {
+    if (
+      options.devServerTarget &&
+      typeof options.devServerTarget === 'string'
+    ) {
       server = await startDevServer(context, options.devServerTarget);
       const result = await server.result;
       baseURL = result.baseUrl;

--- a/src/builders/playwright/schema.json
+++ b/src/builders/playwright/schema.json
@@ -8,12 +8,118 @@
       "description": "Dev server target to run tests against",
       "type": "string"
     },
+    "files": {
+      "description": "Run a test file with the given file name or in the given directory. To specify multiple names, repeat this argument.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+
+    "config": {
+      "description": "Configuration file. If not passed, defaults to `playwright.config.ts` or `playwright.config.js` in the current directory.",
+      "type": "string"
+    },
     "debug": {
-      "description": "Run tests with Playwright Inspector",
+      "description": "Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options.",
       "type": "boolean"
     },
+    "fail-on-flaky-tests": {
+      "description": "Fails test runs that contain flaky tests. By default flaky tests count as successes.",
+      "type": "boolean"
+    },
+    "forbid-only": {
+      "description": "Whether to disallow `test.only`. Useful on CI.",
+      "type": "boolean"
+    },
+    "global-timeout": {
+      "description": "Total timeout for the whole test run in milliseconds. By default, there is no global timeout.",
+      "type": "number"
+    },
+    "grep": {
+      "description": "Only run tests matching this regular expression.",
+      "type": "string",
+      "alias": "g"
+    },
+    "grep-invert": {
+      "description": "Only run tests not matching this regular expression. The opposite of `--grep`. The filter does not apply to the tests from dependency projects, i.e. Playwright will still run all tests from project dependencies.",
+      "type": "string"
+    },
+    "headed": {
+      "description": "Run tests in headed browsers. Useful for debugging.",
+      "type": "boolean"
+    },
+    "ignore-snapshots": {
+      "description": "Whether to ignore snapshots. Use this when snapshot expectations are known to be different, e.g. running tests on Linux against Windows screenshots.",
+      "type": "boolean"
+    },
+    "last-failed": {
+      "description": "Only re-run the failures.",
+      "type": "boolean"
+    },
+    "list": {
+      "description": "List all the tests, but do not run them.",
+      "type": "boolean"
+    },
+    "max-failures": {
+      "description": "Stop after the first `N` test failures.",
+      "type": "number"
+    },
+    "x": {
+      "description": "Stop after the first failure.",
+      "type": "boolean"
+    },
+    "no-deps": {
+      "description": "Ignore the dependencies between projects and behave as if they were not specified.",
+      "type": "boolean"
+    },
+    "output": {
+      "description": "Directory for artifacts produced by tests.",
+      "type": "string",
+      "default": "test-results"
+    },
+    "only-changed": {
+      "description": "Only run test files that have been changed between working tree and \"ref\". Defaults to running all uncommitted changes with ref=HEAD. Only supports Git.",
+      "type": "string"
+    },
+    "pass-with-no-tests": {
+      "description": "Allows the test suite to pass when no files are found.",
+      "type": "boolean"
+    },
+    "project": {
+      "description": "Only run tests from the specified projects, supports '*' wildcard. Defaults to running all projects defined in the configuration file.",
+      "type": "string"
+    },
+    "quiet": {
+      "description": "Whether to suppress stdout and stderr from the tests.",
+      "type": "boolean"
+    },
+    "repeat-each": {
+      "description": "Run each test `N` times.",
+      "type": "number",
+      "default": 1
+    },
+    "reporter": {
+      "description": "Choose a reporter: minimalist `dot`, concise `line` or detailed `list`.",
+      "enum": ["dot", "line", "list"]
+    },
+    "retries": {
+      "description": "The maximum number of retries for flaky tests, defaults to zero (no retries).",
+      "type": "number",
+      "default": 0
+    },
+    "shard": {
+      "description": "Shard tests and execute only selected shard, specified in the form `current/all`, 1-based, for example `3/5`.",
+      "type": "string",
+      "pattern": "^\\d+\\/\\d+$"
+    },
+    "timeout": {
+      "description": "Maximum timeout in milliseconds for each test.",
+      "type": "number",
+      "default": 30000
+    },
     "trace": {
-      "description": "Force tracing mode",
+      "description": "Force tracing mode, can be `on`, `off`, `on-first-retry`, `on-all-retries`, `retain-on-failure`",
       "enum": [
         "on",
         "off",
@@ -23,13 +129,23 @@
         "retain-on-first-failure"
       ]
     },
-    "u": {
-      "description": "Update snapshots with actual results",
-      "type": "boolean"
+    "tsconfig": {
+      "description": "Path to a single tsconfig applicable to all imported files.",
+      "type": "string"
     },
     "ui": {
-      "description": "Run tests in interactive UI mode",
+      "description": "Run tests in interactive UI mode, with a built-in watch mode.",
       "type": "boolean"
+    },
+    "update-snapshots": {
+      "description": "Whether to update snapshots with actual results instead of comparing them. Use this when snapshot expectations have changed.",
+      "type": "boolean",
+      "alias": "u"
+    },
+    "workers": {
+      "description": "The maximum number of concurrent worker processes that run in parallel.",
+      "type": "number",
+      "alias": "j"
     }
   }
 }


### PR DESCRIPTION
I needed some more Playwright CLI options in `ng e2e` so I now added all of them.

It was necessary to list them all in the schema, otherwise Angular won't accept them. I used the descriptions from the Playwright Docs. The code does no addition validation and would accept all options, so for future changes it'd be sufficient to just change the schema.

For the files as non-option arguments I had to make a workaround with a new `--files` argument. See the Readme changes for details.