### PR TITLE
fix: allow hyphenated options

### DIFF
--- a/src/builders/playwright/index.spec.ts
+++ b/src/builders/playwright/index.spec.ts
@@ -146,4 +146,20 @@ describe('Playwright builder', () => {
     );
     expect(output.success).toBeTruthy();
   });
+
+  it('should convert camelCase options to kebab-case', async () => {
+    const run = await architect.scheduleBuilder(
+      'playwright-ng-schematics:playwright',
+      { updateSnapshots: true },
+    );
+    await run.stop();
+    const output = await run.result;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'npx playwright test',
+      ['--update-snapshots'],
+      expect.anything(),
+    );
+    expect(output.success).toBeTruthy();
+  });
 });

--- a/src/builders/playwright/index.ts
+++ b/src/builders/playwright/index.ts
@@ -37,8 +37,11 @@ function buildArgs(options: JsonObject): string[] {
         return [];
       }
 
+      // options automatically got converted to camelCase, so we have to convert them back to kebab-case for Playwright.
+      const kebabCaseKey = camelCaseToKebabCase(key);
+
       const dashes = key.length === 1 ? '-' : '--';
-      const argument = `${dashes}${key}`;
+      const argument = `${dashes}${kebabCaseKey}`;
 
       if (typeof value === 'boolean') {
         if (value) {
@@ -49,6 +52,14 @@ function buildArgs(options: JsonObject): string[] {
       return [argument, String(value)];
     }),
   ];
+}
+
+function camelCaseToKebabCase(text: string): string {
+  // Source: https://stackoverflow.com/a/67243723
+  return text.replace(
+    /[A-Z]+(?![a-z])|[A-Z]/g,
+    (match, offset) => (offset ? '-' : '') + match.toLowerCase(),
+  );
 }
 
 async function startDevServer(


### PR DESCRIPTION
While switching our repositories to this lib I noticed that there's another bug I added in my recent change. Options with hyphens like `--update-snapshots` arrive in camelCase `updateSnapshots`, which is not accepted by Playwright. Therefore I now added code to convert them back to kebab-case, before passing them to Playwright.

Btw., Playwright internally converts the options to camelCase again.