### PR TITLE
fix(14): generate a tsconfig file in e2e with ng add

### DIFF
--- a/src/schematics/ng-add/files/e2e/tsconfig.json
+++ b/src/schematics/ng-add/files/e2e/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts"]
+}

--- a/src/schematics/ng-add/index.spec.ts
+++ b/src/schematics/ng-add/index.spec.ts
@@ -59,6 +59,7 @@ describe('ng-add', () => {
     const tree = await runner.runSchematic('ng-add', {}, appTree);
 
     expect(tree.files).toContain('/playwright.config.ts');
+    expect(tree.files).toContain('/e2e/tsconfig.json');
     expect(tree.files).toContain('/e2e/example.spec.ts');
 
     const packageJSON = JSON.parse(tree.readContent('/package.json'));


### PR DESCRIPTION
Fixes #14

I opted for the same solution as create-vue did for its integration of playwright.