### PR TITLE
chore: bump dependencies to angular 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "21.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
-        "@angular-devkit/core": "^21.0.0",
-        "@angular-devkit/schematics": "^21.0.0"
+        "@angular-devkit/architect": ">= 0.2200.0 < 0.2300.0",
+        "@angular-devkit/core": "^22.0.0",
+        "@angular-devkit/schematics": "^22.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@schematics/angular": "^21.0.0",
+        "@schematics/angular": "^22.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.17.23",
         "cpy-cli": "^5.0.0",
@@ -25,9 +25,9 @@
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
-        "@angular-devkit/core": "^21.0.0",
-        "@angular-devkit/schematics": "^21.0.0"
+        "@angular-devkit/architect": ">= 0.2200.0 < 0.2300.0",
+        "@angular-devkit/core": "^22.0.0",
+        "@angular-devkit/schematics": "^22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -45,30 +45,30 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2102.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.7.tgz",
-      "integrity": "sha512-4K/5hln9iaPEt3F/NyYqncNLvYpzSjRslEkHl2xIgZwQsIFHEvhnDRBYj2/oatURQhBqO/Yu15z/icVOYLxuTg==",
+      "version": "0.2200.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.1.tgz",
+      "integrity": "sha512-Q3DfpgEIiHtG7uSUO8Tsm35rOeUbJfuxM9pi7cCyC8DvC/z1yNYm7/xEitlEYPzJmSLmks3eqlsaGnYhh0VLVg==",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.7",
+        "@angular-devkit/core": "22.0.1",
         "rxjs": "7.8.2"
       },
       "bin": {
         "architect": "bin/cli.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.7.tgz",
-      "integrity": "sha512-DONYY5u4IENO2qpd23mODaE4JI2EIohWV1kuJnsU9HIcm5wN714QB2z9WY/s4gLfUiAMIUu/8lpnW/0kOQZAnQ==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.1.tgz",
+      "integrity": "sha512-77/WsCAbqGkumDfm/kkw2mFh/42DNF0hB02TvivlfiSC/KfK9DsHg7sKvTlNcuY14ZT/3iHhojLyNBc2HytuvQ==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.18.0",
+        "ajv": "8.20.0",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
         "picomatch": "4.0.4",
@@ -76,7 +76,7 @@
         "source-map": "0.7.6"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       },
@@ -102,19 +102,19 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.7.tgz",
-      "integrity": "sha512-LYAjjUI1qM7pR/sd0yYt8OLA6ljOOXjcfzV40I5XQNmhAxq90YYS5xwMcixOmWX+z5zvCYGvPXvJGWjzio6SUg==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.1.tgz",
+      "integrity": "sha512-GWou5meX3vAvqQEkox7xYMT9tIrYBVl0StbP7rGH5yMrzngvi6eyikMiUYnmMvoEoBK9gFNnXaAKeeu2aWvb3Q==",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.7",
+        "@angular-devkit/core": "22.0.1",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
-        "ora": "9.3.0",
+        "ora": "9.4.0",
         "rxjs": "7.8.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
@@ -1267,20 +1267,35 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "21.2.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.7.tgz",
-      "integrity": "sha512-aqEj3RyBtmH+41HZvrbfrpCo0e+0NzwyQyNSC/wLDShVqoidBtPbEdHU1FZ4+ni41da7rI3F12gUuAHws27kMA==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.1.tgz",
+      "integrity": "sha512-JRtJ9x0CaYIBLdPERr7B66ZSSLy4phkb7KtFIcD8RC2nAmnL/elevL2wg2Miih7ww0zmhiblS3LDE/abqSLRAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.7",
-        "@angular-devkit/schematics": "21.2.7",
-        "jsonc-parser": "3.3.1"
+        "@angular-devkit/core": "22.0.1",
+        "@angular-devkit/schematics": "22.0.1",
+        "jsonc-parser": "3.3.1",
+        "typescript": "6.0.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1509,9 +1524,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2565,9 +2580,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4033,9 +4048,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -4044,7 +4059,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -4079,9 +4094,9 @@
       }
     },
     "node_modules/ora/node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "testing"
   ],
   "dependencies": {
-    "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
-    "@angular-devkit/core": "^21.0.0",
-    "@angular-devkit/schematics": "^21.0.0"
+    "@angular-devkit/architect": ">= 0.2200.0 < 0.2300.0",
+    "@angular-devkit/core": "^22.0.0",
+    "@angular-devkit/schematics": "^22.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@schematics/angular": "^21.0.0",
+    "@schematics/angular": "^22.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.17.23",
     "cpy-cli": "^5.0.0",
@@ -43,9 +43,9 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
-    "@angular-devkit/core": "^21.0.0",
-    "@angular-devkit/schematics": "^21.0.0"
+    "@angular-devkit/architect": ">= 0.2200.0 < 0.2300.0",
+    "@angular-devkit/core": "^22.0.0",
+    "@angular-devkit/schematics": "^22.0.0"
   },
   "builders": "./lib/builders/builders.json",
   "schematics": "./lib/schematics/collection.json",


### PR DESCRIPTION
closes #36

Bumps Angular deps to 22 and jest to 30.
Note that this also makes sure the spec files are not part of the bundled package (through a tsconfig.build.json).